### PR TITLE
Remove unused comment in navigation.scss

### DIFF
--- a/overrides/assets/css/modules/navigation.scss
+++ b/overrides/assets/css/modules/navigation.scss
@@ -1,6 +1,5 @@
 // Navigation and tabs styling
 
-// Tabs styling
 .md-tabs {
   color: #fff !important;
 }


### PR DESCRIPTION
The comment regarding tabs styling was redundant and has been removed. This helps to keep the codebase clean and more maintainable.