### PR TITLE
Fix typo in Datenschutz link title in footer

### DIFF
--- a/overrides/partials/footer.html
+++ b/overrides/partials/footer.html
@@ -33,7 +33,7 @@
 <div class="md-footer-custom-links">
     <a href="https://satware.com/custom/index/sCustom/1" target="_blank" title="Kontakt">Kontakt</a>
     <a href="{{ config.site_url }}impressum/" title="Impressum">Impressum</a>
-    <a href="{{ config.site_url }}/datenschutz/" title="sDatenschutzerklärung">Datenschutz</a>
+    <a href="{{ config.site_url }}/datenschutz/" title="Datenschutzerklärung">Datenschutz</a>
     <!--<a href="/barrierefreiheitserklaerung" title="Barrierefreiheitserklärung">Barrierefreiheitserklärung</a>-->
     <a href="{{ config.site_url }}satway/" title="satWay Prinzipien">saTway</a>
     <a href="https://satware.com/newsletter" target="_blank" title="Newsletter">Newsletter</a>


### PR DESCRIPTION
Corrected the link title from "sDatenschutzerklärung" to "Datenschutzerklärung" for consistency and clarity. This improves the accuracy of the footer content.