### PR TITLE
Adjust margin for icons in blog sidebar navigation

### DIFF
--- a/overrides/assets/css/modules/blog.scss
+++ b/overrides/assets/css/modules/blog.scss
@@ -49,3 +49,11 @@
     font-size: inherit;
   }
 }
+
+.md-sidebar--post{
+  .md-nav__link{
+    svg{
+      margin-top: 5px;
+    }
+  }
+}


### PR DESCRIPTION
Added a 5px top margin to SVG icons in the blog post sidebar navigation links. This improves alignment and visual consistency in the blog layout.